### PR TITLE
Fix module directory constant and package.json

### DIFF
--- a/.obsidian/plugins/vaultos/package.json
+++ b/.obsidian/plugins/vaultos/package.json
@@ -4,9 +4,8 @@
   "description": "The VaultOS kernel plugin for managing subplugins and vault automations.",
   "main": "main.js",
   "scripts": {
-    "build": "rollup -c && node dist/ops/compilator.js"
-  },
-  "dev": "rollup -c -w"
+    "build": "rollup -c && node dist/ops/compilator.js",
+    "dev": "rollup -c -w"
   },
   "devDependencies": {
     "@types/node": "^22.15.28",

--- a/.obsidian/plugins/vaultos/src/core/orchestrator.ts
+++ b/.obsidian/plugins/vaultos/src/core/orchestrator.ts
@@ -9,7 +9,9 @@ import { logModuleAction } from '../logger';
 import { updateModuleCache } from '../cache';
 import * as fs from 'fs';
 
-const MODULES_DIR = "vaultos/scr/modules";
+// Directory containing VaultOS submodules
+// Typo fixed: was "scr" instead of "src"
+const MODULES_DIR = "vaultos/src/modules";
 
 /**
  * Run full build pipeline on a single module
@@ -62,7 +64,13 @@ export function runModuleBuildPipeline(moduleName: string) {
  * Run build pipeline on all existing modules
  */
 export function runFullBuildPipeline() {
-  const modules = fs.readdirSync(path.resolve(MODULES_DIR), { withFileTypes: true })
+  const fullPath = path.resolve(MODULES_DIR);
+  if (!fs.existsSync(fullPath)) {
+    console.warn("❌ Modules directory not found:", fullPath);
+    return;
+  }
+
+  const modules = fs.readdirSync(fullPath, { withFileTypes: true })
     .filter(d => d.isDirectory())
     .map(d => d.name);
 


### PR DESCRIPTION
## Summary
- correct modules path in orchestrator
- guard against missing modules directory
- fix malformed `package.json` scripts section

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d57791dc83229f8b7a7f05856795