### PR TITLE
Fix subplugin validator filename

### DIFF
--- a/.obsidian/plugins/vaultos/README.md
+++ b/.obsidian/plugins/vaultos/README.md
@@ -30,7 +30,7 @@ Each subplugin is self-contained and may include:
 ```txt
 vaultos_myplugin/
 ├── index.ts
-├── wizzard.ts
+├── wizard.ts
 ├── config/
 │   └── config.json
 ├── views.ts

--- a/.obsidian/plugins/vaultos/src/ops/validator.ts
+++ b/.obsidian/plugins/vaultos/src/ops/validator.ts
@@ -3,7 +3,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-const REQUIRED_FILES = ['index.ts', 'wizzard.ts', 'README.md', 'config/config.json'];
+const REQUIRED_FILES = ['index.ts', 'wizard.ts', 'README.md', 'config/config.json'];
 
 export function validateModuleStructure(modulePath: string): string[] {
   const missing = [];


### PR DESCRIPTION
## Summary
- correct required filename from `wizzard.ts` to `wizard.ts`
- update README example structure accordingly

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d79b2b808322856b01ee8af6c5f5