### PR TITLE
Fix path comments in plugin sources

### DIFF
--- a/.obsidian/plugins/vaultos/src/core/orchestrator.ts
+++ b/.obsidian/plugins/vaultos/src/core/orchestrator.ts
@@ -1,4 +1,4 @@
-// scr/modules/module-manager/ops/orchestrator.ts
+// src/core/orchestrator.ts
 
 import * as path from 'path';
 import { validateModuleStructure } from '../ops/validator';

--- a/.obsidian/plugins/vaultos/src/ops/compilator.ts
+++ b/.obsidian/plugins/vaultos/src/ops/compilator.ts
@@ -1,4 +1,4 @@
-// scr/modules/module-manager/ops/compilator.ts
+// src/ops/compilator.ts
 
 import * as fs from 'fs';
 import * as path from 'path';

--- a/.obsidian/plugins/vaultos/src/ops/converter.ts
+++ b/.obsidian/plugins/vaultos/src/ops/converter.ts
@@ -1,4 +1,4 @@
-// scr/modules/module-manager/ops/converter.ts
+// src/ops/converter.ts
 
 import * as fs from 'fs';
 import * as path from 'path';

--- a/.obsidian/plugins/vaultos/src/ops/relocator.ts
+++ b/.obsidian/plugins/vaultos/src/ops/relocator.ts
@@ -1,4 +1,4 @@
-// scr/modules/module-manager/ops/relocator.ts
+// src/ops/relocator.ts
 
 import * as fs from 'fs';
 import * as path from 'path';

--- a/.obsidian/plugins/vaultos/src/ops/validator.ts
+++ b/.obsidian/plugins/vaultos/src/ops/validator.ts
@@ -1,4 +1,4 @@
-// scr/modules/module-manager/ops/validator.ts
+// src/ops/validator.ts
 
 import * as fs from 'fs';
 import * as path from 'path';


### PR DESCRIPTION
## Summary
- update outdated path comments for plugin source files

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d79dcb2c83229687a0d38b90a13e