### PR TITLE
Add validator test and npm test script

### DIFF
--- a/.obsidian/plugins/vaultos/.gitignore
+++ b/.obsidian/plugins/vaultos/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+tests/dist/

--- a/.obsidian/plugins/vaultos/package.json
+++ b/.obsidian/plugins/vaultos/package.json
@@ -5,7 +5,8 @@
   "main": "main.js",
   "scripts": {
     "build": "rollup -c && node dist/ops/compilator.js",
-    "dev": "rollup -c -w"
+    "dev": "rollup -c -w",
+    "test": "tsc -p tests/tsconfig.json && node --test tests/dist/tests/validator.test.js"
   },
   "devDependencies": {
     "@types/node": "^22.15.28",

--- a/.obsidian/plugins/vaultos/tests/node.d.ts
+++ b/.obsidian/plugins/vaultos/tests/node.d.ts
@@ -1,0 +1,5 @@
+declare module 'fs';
+declare module 'path';
+declare module 'os';
+declare module 'node:test';
+declare module 'node:assert/strict';

--- a/.obsidian/plugins/vaultos/tests/tsconfig.json
+++ b/.obsidian/plugins/vaultos/tests/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "../",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": [],
+    "typeRoots": []
+  },
+  "include": [
+    "../src/ops/validator.ts",
+    "validator.test.ts",
+    "node.d.ts"
+  ]
+}

--- a/.obsidian/plugins/vaultos/tests/validator.test.ts
+++ b/.obsidian/plugins/vaultos/tests/validator.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { validateModuleStructure } from '../src/ops/validator';
+
+function setupTempModule(files: Record<string, string>): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vaultos-test-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(tmpDir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  return tmpDir;
+}
+
+test('reports missing files', () => {
+  const mod = setupTempModule({
+    'index.ts': '',
+    'README.md': '',
+    // intentionally omit wizzard.ts and config/config.json
+  });
+
+  const missing = validateModuleStructure(mod).sort();
+  assert.deepStrictEqual(missing, ['config/config.json', 'wizzard.ts']);
+
+  fs.rmSync(mod, { recursive: true, force: true });
+});
+
+test('passes when all files exist', () => {
+  const mod = setupTempModule({
+    'index.ts': '',
+    'wizzard.ts': '',
+    'README.md': '',
+    'config/config.json': '{}',
+  });
+
+  const missing = validateModuleStructure(mod);
+  assert.deepStrictEqual(missing, []);
+
+  fs.rmSync(mod, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- add Node test for `validateModuleStructure`
- compile tests with custom tsconfig
- ignore compiled test output
- add `test` script to `package.json`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841d7a058388322821461f9c0e1c42a