### PR TITLE
Remove plugin archive and refine gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
 node_modules/
+# Build output
 dist/
 tests/dist/
+
+# Temporary files
+*.log
+*.tmp
+*.temp
+.tmp/
+.temp/
+.DS_Store
+.vscode/
+*~
+
+# Obsidian plugin archives
+.obsidian/plugins/vaultos.zip


### PR DESCRIPTION
## Summary
- remove obsolete `vaultos.zip` from tracked plugins
- expand `.gitignore` to cover build output and temporary files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845c29129748322b6d1c220436fedd1