### PR TITLE
Implement watcher, view, logger, cache utilities

### DIFF
--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -1,0 +1,36 @@
+// src/core/cache.ts
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { ensureDir } from '../utils/file';
+
+const CACHE_FILE = path.resolve('data/module-metadata.json');
+let cache: Record<string, any> | null = null;
+
+function loadCache() {
+  if (cache === null) {
+    if (fs.existsSync(CACHE_FILE)) {
+      try {
+        cache = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf-8'));
+      } catch {
+        cache = {};
+      }
+    } else {
+      cache = {};
+    }
+  }
+}
+
+export function updateModuleCache(module: string, data: Record<string, any>) {
+  loadCache();
+  if (!cache) cache = {};
+  if (!cache[module]) cache[module] = {};
+  Object.assign(cache[module], data);
+  ensureDir(path.dirname(CACHE_FILE));
+  fs.writeFileSync(CACHE_FILE, JSON.stringify(cache, null, 2));
+}
+
+export function getModuleMetadata(): Record<string, any> {
+  loadCache();
+  return cache || {};
+}

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,0 +1,20 @@
+// src/core/logger.ts
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { ensureDir } from '../utils/file';
+
+const LOG_FILE = path.resolve('data/vaultos.log');
+
+export interface ModuleLogEntry {
+  action: string;
+  module: string;
+  result: string;
+  [key: string]: any;
+}
+
+export function logModuleAction(entry: ModuleLogEntry) {
+  ensureDir(path.dirname(LOG_FILE));
+  const line = JSON.stringify({ timestamp: new Date().toISOString(), ...entry });
+  fs.appendFileSync(LOG_FILE, line + '\n');
+}

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -5,8 +5,8 @@ import { validateModuleStructure } from '../ops/validator';
 import { convertModuleToJson } from '../ops/converter';
 import { relocateModuleJson } from '../ops/relocator';
 import { compileManifest } from '../ops/compilator';
-import { logModuleAction } from '../logger';
-import { updateModuleCache } from '../cache';
+import { logModuleAction } from './logger';
+import { updateModuleCache } from './cache';
 import * as fs from 'fs';
 
 // Directory containing VaultOS submodules

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -1,0 +1,33 @@
+// src/core/view.ts
+
+import { App, ItemView, WorkspaceLeaf } from 'obsidian';
+
+export const VAULTOS_PANEL_VIEW = 'VAULTOS_PANEL_VIEW';
+
+export class VaultOSPanelView extends ItemView {
+  constructor(leaf: WorkspaceLeaf) {
+    super(leaf);
+  }
+
+  getViewType(): string {
+    return VAULTOS_PANEL_VIEW;
+  }
+
+  getDisplayText(): string {
+    return 'VaultOS';
+  }
+
+  async onOpen() {
+    const container = this.containerEl.children[1];
+    container.empty();
+    container.createEl('h2', { text: 'VaultOS Module Manager' });
+  }
+
+  async onClose() {
+    // nothing
+  }
+}
+
+export function registerModuleManagerView(app: App) {
+  app.workspace.registerView(VAULTOS_PANEL_VIEW, (leaf) => new VaultOSPanelView(leaf));
+}

--- a/src/core/watcher.ts
+++ b/src/core/watcher.ts
@@ -1,0 +1,25 @@
+// src/core/watcher.ts
+
+import { App, Plugin } from 'obsidian';
+import * as fs from 'fs';
+import * as path from 'path';
+import { runModuleBuildPipeline } from './orchestrator';
+import { ensureDir } from '../utils/file';
+
+const SUBPLUGIN_PREFIX = 'vaultos_';
+
+export function registerWatcher(app: App, plugin: Plugin) {
+  const pluginsDir = path.join(app.vault.adapter.basePath, '.obsidian/plugins');
+  ensureDir(pluginsDir);
+
+  const watcher = fs.watch(pluginsDir, (event, filename) => {
+    if (event === 'rename' && filename && filename.startsWith(SUBPLUGIN_PREFIX)) {
+      const full = path.join(pluginsDir, filename);
+      if (fs.existsSync(full) && fs.statSync(full).isDirectory()) {
+        runModuleBuildPipeline(filename);
+      }
+    }
+  });
+
+  plugin.register(() => watcher.close());
+}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,0 +1,9 @@
+// src/utils/file.ts
+
+import * as fs from 'fs';
+
+export function ensureDir(dir: string) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}


### PR DESCRIPTION
## Summary
- add watcher for new `vaultos_*` plugin directories
- implement basic VaultOS panel view
- provide logging and module cache helpers
- ensure path creation helper
- update orchestrator imports