### PR TITLE
Remove self reference dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "vaultos",
       "version": "0.1.0",
       "license": "MIT",
-      "dependencies": {
-        "vaultos": "file:"
-      },
       "devDependencies": {
         "@types/node": "^22.15.28",
         "obsidian": "^1.8.7",
@@ -439,10 +436,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/vaultos": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,5 @@
   "keywords": [],
   "author": "Charlie Bouchard",
   "license": "MIT",
-  "dependencies": {
-    "vaultos": "file:"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
## Summary
- remove local `vaultos` dependency from package.json
- keep the lockfile consistent
