### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ Whether you're building a single subplugin or orchestrating dozens, VaultOS give
 git clone https://github.com/PtiCalin/vaultos.git
 cd vaultos
 
-# 2. Install dependencies from the repository root
-npm install
+# 2. Install dependencies and run tests
+./setup.sh
+#    Run `ENABLE_NET=1 ./setup.sh` if you need to fetch packages from the internet
 
 # 3. Build the plugin
 npm run build

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$ENABLE_NET" = "1" ]; then
+  echo "Network access requested for dependency installation..."
+  # Add network setup commands here if needed
+fi
+
+npm ci
+npm test


### PR DESCRIPTION
## Summary
- add `setup.sh` for installing Node dependencies and running tests
- document setup script usage in README

## Testing
- `npm test`
